### PR TITLE
Add tests and search route

### DIFF
--- a/app.py
+++ b/app.py
@@ -91,6 +91,17 @@ def search_inventory():
     data = [dict(row) for row in results]
     return jsonify(data)
 
+@app.route("/search_inventory_movements")
+def search_inventory_movements():
+    db = get_db()
+    query = request.args.get("q", "").strip()
+    results = db.execute(
+        "SELECT * FROM inventory_movements WHERE name LIKE ? OR product_id LIKE ?",
+        (f"%{query}%", f"%{query}%")
+    ).fetchall()
+    data = [dict(row) for row in results]
+    return jsonify(data)
+
 @app.route("/delivery", methods=["POST"])
 def delivery():
     if request.method == "POST":

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,47 @@
+import sqlite3
+import shutil
+import tempfile
+import pytest
+from flask import g
+
+import app
+
+@pytest.fixture
+def client(tmp_path):
+    db_path = tmp_path / "test.db"
+    shutil.copy("databases.db", db_path)
+
+    def get_test_db():
+        if "db" not in g:
+            g.db = sqlite3.connect(db_path)
+            g.db.row_factory = sqlite3.Row
+        return g.db
+
+    app.get_db = get_test_db
+    app.config["TESTING"] = True
+
+    with app.app.test_client() as client:
+        with app.app.app_context():
+            yield client
+        g.pop("db", None)
+
+def test_register_get(client):
+    resp = client.get('/register')
+    assert resp.status_code == 200
+
+def test_index_payment_post_redirect(client):
+    data = {
+        'movement_id': '1',
+        'draft_id': '0',
+        'amount': '5',
+        'payment_method[]': 'cash',
+        'payment_amount[]': '5'
+    }
+    resp = client.post('/index_payment', data=data)
+    assert resp.status_code in (301, 302)
+
+def test_search_inventory_movements_returns_json(client):
+    resp = client.get('/search_inventory_movements?q=test')
+    assert resp.status_code == 200
+    assert resp.is_json
+    assert isinstance(resp.get_json(), list)


### PR DESCRIPTION
## Summary
- add `/search_inventory_movements` route
- add test suite using temporary database
- cover `/register`, `/index_payment`, and `/search_inventory_movements`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement blinker==1.9.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6841d1a3c7288324814a316e7ab9e063